### PR TITLE
An alternative cleaned fast set overlap implementation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
       dockerfile: docker/DockerfileAPI
-    image: maayanlab/enrichmentapi:1.3.1
+    image: maayanlab/enrichmentapi:1.3.2
     environment:
       token: token
       AWS_BUCKET: bucket

--- a/src/main/java/fastset/FastHashSeq.java
+++ b/src/main/java/fastset/FastHashSeq.java
@@ -1,0 +1,54 @@
+package fastset;
+
+import fastset.FastSet;
+import java.util.Arrays;
+
+/**
+ * @author Daniel J. B. Clarke - maayanlab
+ *
+ * The sequantial part of a keyed hash set, useful for fast HashSet computation, but not
+ *  capable of set operations itself. Mainly here to provide O(1) insertion/clear and
+ *  instant sequential access.
+ */
+public class FastHashSeq {
+  private short[] value_seq = null;
+  private short n = 0;
+  private short min_value;
+  private short max_value;
+
+  public FastHashSeq(short min, short max) {
+    min_value = min;
+    max_value = max;
+    int size = max_value - min_value + 1; // (1) inclusive bounds
+    value_seq = new short[size];
+    n = 0;
+  }
+
+  public void add(short value) throws Exception {
+    value_seq[n] = value;
+    n += 1;
+  }
+
+  public short value(int index) throws Exception {
+    return value_seq[index];
+  }
+
+  public short size() {
+    return n;
+  }
+
+  public void clear() throws Exception {
+    n = 0;
+  }
+
+  public void overlapWithArray(FastSet a, short[] b) throws Exception {
+    this.clear();
+    for (int i = 0; i < b.length; i++) {
+      if (a.contains(b[i])) this.add(b[i]);
+    }
+  }
+
+  public short[] toArray() {
+    return Arrays.copyOfRange(value_seq, 0, n);
+  }
+}

--- a/src/main/java/fastset/FastHashSet.java
+++ b/src/main/java/fastset/FastHashSet.java
@@ -1,0 +1,55 @@
+package fastset;
+
+import fastset.FastSet;
+
+/**
+ * @author Daniel J. B. Clarke - maayanlab
+ * 
+ * We implement a fast hashset by storing whether or not the value is set in a boolean array
+ *  sized accordingly to fit some bounds, but offer no obvious ways to iterate through the set
+ *  as such *clear* is somewhat slow. If you need clear / iteration through the set sey FastKeyedHashSet.
+ */
+public class FastHashSet implements FastSet {
+  private boolean[] value_set = null;
+  private short n = 0;
+  private short min_value;
+  private short max_value;
+
+  public FastHashSet(short min, short max) {
+    min_value = min;
+    max_value = max;
+    int size = max_value - min_value + 2; // (1) inclusive bounds + (1) skip index[0]
+    value_set = new boolean[size]; // wasting 1 allocated element arguably cheaper than treating something other than 0 as null
+    n = 0;
+  }
+
+  private int encode_index(short value) throws Exception {
+    if (value < min_value || value > max_value) throw new Exception("Out of bounds: " + value);
+    return (int)(value - min_value) + 1;
+  }
+
+  public void add(short value) throws Exception {
+    if (this.contains(value)) return;
+    n += 1;
+    value_set[encode_index(value)] = true;
+  }
+
+  public boolean contains(short value) throws Exception {
+    return value_set[encode_index(value)];
+  }
+
+  public short size() {
+    return n;
+  }
+
+  public void clear() throws Exception {
+    // WARNING: this should not be used, if you need it use keyedhashset
+    //  the only reason I have it is because it is likely still better than re-malloc
+    for (short i = min_value; i <= max_value; i++) {
+      if (value_set[encode_index(i)]) {
+        value_set[encode_index(i)] = false;
+        n -= 1;
+      }
+    }
+  }
+}

--- a/src/main/java/fastset/FastKeyedHashSet.java
+++ b/src/main/java/fastset/FastKeyedHashSet.java
@@ -1,0 +1,133 @@
+package fastset;
+
+import java.util.Arrays;
+import fastset.FastSet;
+
+/**
+ * @author Daniel J. B. Clarke - maayanlab
+ * 
+ * A full keyed hash capable of very fast lookups and iteration. Can interoperate with
+ *  FastSets, and is ideal for performing overlap computations given that it allows you
+ *  to fetch the results reasonably efficiently, while memory can be much cheaper using the FastHashSet.
+ */
+public class FastKeyedHashSet implements FastSet  {
+  private short[] index_to_value = null;
+  private short[] value_to_index = null;
+  private short n = 0;
+  private short min_value;
+  private short max_value;
+
+  public FastKeyedHashSet(short min, short max) {
+    min_value = min;
+    max_value = max;
+    int size = max_value - min_value + 2; // (1) inclusive bounds + (1) skip index[0]
+    index_to_value = new short[size]; // wasting 1 allocated element arguably cheaper than treating something other than 0 as null
+    value_to_index = new short[size]; // yes, there are *two* tables, if you want one you can't seq through it, FastHashSet.
+    n = 0;
+  }
+
+  private int encode_index(short value) throws Exception {
+    if (value < min_value || value > max_value) throw new Exception("Out of bounds: " + value);
+    return (int)(value - min_value) + 1;
+  }
+
+  private short decode_index(int index) throws Exception {
+    short value = (short)((index - 1) + min_value);
+    if (value < min_value || value > max_value) throw new Exception("Out of bounds: " + value);
+    return value;
+  }
+
+  public void add(short value) throws Exception {
+    if (this.contains(value)) return;
+    n += 1;
+    index_to_value[n] = value;
+    value_to_index[encode_index(value)] = n;
+  }
+
+  public int index(short value) throws Exception {
+    return value_to_index[encode_index(value)] - 1;
+  }
+
+  public short value(int index) throws Exception {
+    return index_to_value[index + 1];
+  }
+
+  public boolean contains(short value) throws Exception {
+    return value_to_index[encode_index(value)] != 0;
+  }
+
+  public short size() {
+    return n;
+  }
+
+  public void clear() throws Exception {
+    while (n > 0) {
+      value_to_index[encode_index(index_to_value[n])] = 0;
+      index_to_value[n] = 0;
+      n -= 1;
+    }
+  }
+
+  public void overlap(FastKeyedHashSet a, FastKeyedHashSet b) throws Exception {
+    this.clear();
+    if (a.size() <= b.size()) {
+      for (int i = 0; i < a.size(); i++) {
+        short v = a.value(i);
+        if (b.contains(v)) this.add(v);
+      }
+    } else {
+      for (int i = 0; i < b.size(); i++) {
+        short v = b.value(i);
+        if (a.contains(v)) this.add(v);
+      }
+    }
+  }
+
+  public void overlapWithSet(FastKeyedHashSet a, FastSet b) throws Exception {
+    this.clear();
+    for (int i = 0; i < a.size(); i++) {
+      short v = a.value(i);
+      if (b.contains(v)) this.add(v);
+    }
+  }
+
+  public void overlapWithArray(FastSet a, short[] b) throws Exception {
+    this.clear();
+    for (int i = 0; i < b.length; i++) {
+      if (a.contains(b[i])) this.add(b[i]);
+    }
+  }
+
+  public short[] toArray() {
+    return Arrays.copyOfRange(index_to_value, 1, n+1);
+  }
+
+  public static void main(String[] args) throws Exception {
+    short min_value = Short.MIN_VALUE+1;
+    short max_value = Short.MAX_VALUE-1;
+    FastKeyedHashSet a = new FastKeyedHashSet(min_value, max_value);
+    FastKeyedHashSet b = new FastKeyedHashSet(min_value, max_value);
+    FastKeyedHashSet c = new FastKeyedHashSet(min_value, max_value);
+
+    for (short i = -100; i <= 100; i++) {
+      if (i % 5 == 0 || (-i) % 5 == 0) a.add(i);
+      if (i % 10 == 0) b.add(i);
+    }
+    c.overlap(a, b);
+    for (int i = 0; i < c.size(); i++) {
+      System.out.println(c.value(i));
+    }
+
+    System.out.println();
+    a.clear(); b.clear();
+
+    for (short i = -300; i <= 0; i++) {
+      if (i % 5 == 0 || (-i) % 5 == 0) a.add(i);
+      if (i % 10 == 0) b.add(i);
+    }
+    c.overlap(a, b);
+    for (short v : c.toArray()) {
+      System.out.println(v);
+    }
+  }
+}

--- a/src/main/java/fastset/FastSet.java
+++ b/src/main/java/fastset/FastSet.java
@@ -1,0 +1,12 @@
+package fastset;
+
+/**
+ * @author Daniel J. B. Clarke - maayanlab
+ * 
+ * A fastset must minimally be able to add values and report whether or not a value has been registered and how big it is.
+ */
+public interface FastSet {
+  public abstract void add(short value) throws Exception;
+  public boolean contains(short value) throws Exception;
+  public short size() throws Exception;
+}

--- a/src/main/java/serv/Enrichment.java
+++ b/src/main/java/serv/Enrichment.java
@@ -14,7 +14,7 @@ import jsp.Overlap;
 import jsp.Result;
 import math.FastFisher;
 import fastset.FastHashSet;
-import fastset.FastKeyedHashSet;
+import fastset.FastHashSeq;
 
 /**
  * @author Alexander Lachmann - maayanlab
@@ -275,7 +275,7 @@ public class Enrichment {
 		}
 		
 		// create overlap buffer
-		FastKeyedHashSet overset = new FastKeyedHashSet(min_value, max_value);
+		FastHashSeq overset = new FastHashSeq(min_value, max_value);
 		
 		for(String key : signaturefilter) {
 			


### PR DESCRIPTION
Inspired by the code that was there, I went ahead and formalized the concept into a interface and implementations, this helps clean up the code and permits easy independent debugging and integration with other projects as well.

- `fastset.FastSet`:
  - interface defining minimal methods needed to interoperate with these classes:
    - add (add a value to the set)
    - contains (check if a value is in the set)
    - size (the number of unique values registered in the set)
- `fastset.FastHashSet`:
  - implementation of FastSet, stores set in a boolean array
  - values defined in an operating range (min,max) are mapped to indexes in the boolean array
  - add is just an index insertion O(1)
  - contain is just an index lookup O(1)
- `fastset.FastKeyedHashSet`:
  - implementation of FastSet, stores set in a pair of index_to_value & value_to_index arrays permitting lookup either way
  - values defined in an operating range (min,max) are mapped to indexes in the arrays
  - add is just two index insertions O(1)
  - contain is just an index lookup O(1)
  - overlap with another FastSet or with an array is O(number of values in FastKeyedHashSet)
  - overlap with another FastKeyedHashSet is O(min(number of values in FastKeyedHashSet))
- `fastset.FastHashSeq`:
  - a storage container with O(1) insertions, clears, and sequential enumeration (toArray)
  - useful for storing the *results* of FastSets overlaps, being cheaper than FastKeyedHashSet if we don't care about using it as a set afterwards
  - makes FastKeyedHashSet no longer necessary, though it may be useful for something else