### PR TITLE
Modifications in the API

### DIFF
--- a/src/main/java/jsp/Result.java
+++ b/src/main/java/jsp/Result.java
@@ -33,5 +33,17 @@ public class Result implements Comparable<Result>{
 			return 0;
 		}
 	}
+
+	public int compareZscore(Result over) {
+		if(zscore < over.zscore) {
+			return -1;
+		}
+		else if(zscore > over.zscore) {
+			return 1;
+		}
+		else {
+			return 0;
+		}
+	}
 }
 	

--- a/src/main/java/serv/Enrichment.java
+++ b/src/main/java/serv/Enrichment.java
@@ -518,7 +518,7 @@ public class Enrichment {
 			uids.add(signature_id[i]);
 		}
 		
-		uids.retainAll(_signatures);
+		// uids.retainAll(_signatures);
 		boolean showAll = uids.size() > 0;
 		
 		HashMap<String, Short> dictionary = new HashMap<String, Short>();

--- a/src/main/java/serv/Enrichment.java
+++ b/src/main/java/serv/Enrichment.java
@@ -299,7 +299,7 @@ public class Enrichment {
 				return calculateOverlapEnrichment(_db, _entity, _signatures, 0, 0.05);
 			} else {
 				// The database contains rank transformed signatures
-				return calculateRankEnrichment(_db, _entity, _signatures, 0.05);
+				return calculateRankEnrichment(_db, _entity, _signatures, 0.05, false);
 			}
 		}
 		
@@ -497,7 +497,7 @@ public class Enrichment {
 		return results;
 	}
 	
-	public static HashMap<String, Result> calculateRankEnrichment(String _db, String[] _entity, HashSet<String> _signatures, double _significance) {
+	public static HashMap<String, Result> calculateRankEnrichment(String _db, String[] _entity, HashSet<String> _signatures, double _significance, boolean showAll) {
 		
 		HashMap<String, Result> results = new HashMap<String, Result>();
 		
@@ -519,7 +519,7 @@ public class Enrichment {
 		}
 		
 		uids.retainAll(_signatures);
-		boolean showAll = uids.size() > 0;
+		showAll = showAll || uids.size() > 0;
 		
 		HashMap<String, Short> dictionary = new HashMap<String, Short>();
 		for(short i=0; i<entity_id.length; i++) {

--- a/src/main/java/serv/Enrichment.java
+++ b/src/main/java/serv/Enrichment.java
@@ -518,7 +518,7 @@ public class Enrichment {
 			uids.add(signature_id[i]);
 		}
 		
-		// uids.retainAll(_signatures);
+		uids.retainAll(_signatures);
 		boolean showAll = uids.size() > 0;
 		
 		HashMap<String, Short> dictionary = new HashMap<String, Short>();

--- a/src/main/java/serv/EnrichmentTemp.java
+++ b/src/main/java/serv/EnrichmentTemp.java
@@ -226,7 +226,7 @@ public class EnrichmentTemp extends HttpServlet {
 						entities.retainAll(Arrays.asList(((String[]) enrich.datastore.datasets.get(db).getData().get("entity_id"))));
 						signatures.retainAll(Arrays.asList(((String[]) enrich.datastore.datasets.get(db).getData().get("signature_id"))));
 						
-						HashMap<String, Result> enrichResult = enrich.calculateRankEnrichment(db, entities.toArray(new String[0]), signatures, 0.05);
+						HashMap<String, Result> enrichResult = enrich.calculateRankEnrichment(db, entities.toArray(new String[0]), signatures, 0.05, false);
 						returnRankJSON(response, enrichResult, db, signatures, entities, time, 0, 1000);
 						enrichResult = null;
 					}
@@ -891,7 +891,7 @@ public class EnrichmentTemp extends HttpServlet {
 				
 				System.out.println(entities.size()+" - "+signatures.size());
 				
-				HashMap<String, Result> enrichResult = enrich.calculateRankEnrichment(db, entities.toArray(new String[0]), new HashSet<String>(), significance);
+				HashMap<String, Result> enrichResult = enrich.calculateRankEnrichment(db, entities.toArray(new String[0]), new HashSet<String>(), significance, true);
 				System.out.println("ER: "+enrichResult.size());
 				
 				if(minout){
@@ -992,11 +992,11 @@ public class EnrichmentTemp extends HttpServlet {
 				entities.retainAll(Arrays.asList(((String[]) enrich.datastore.datasets.get(db).getData().get("entity_id"))));
 				signatures.retainAll(Arrays.asList(((String[]) enrich.datastore.datasets.get(db).getData().get("signature_id"))));
 				HashSet<String> empty = new HashSet<String>();
-				HashMap<String, Result> enrichResultUp = enrich.calculateRankEnrichment(db, entities.toArray(new String[0]), empty, significance);
+				HashMap<String, Result> enrichResultUp = enrich.calculateRankEnrichment(db, entities.toArray(new String[0]), empty, significance, true);
 				
 				entities = new HashSet<String>(entity_split_down);
 				entities.retainAll(Arrays.asList(((String[]) enrich.datastore.datasets.get(db).getData().get("entity_id"))));
-				HashMap<String, Result> enrichResultDown = enrich.calculateRankEnrichment(db, entities.toArray(new String[0]), empty, significance);
+				HashMap<String, Result> enrichResultDown = enrich.calculateRankEnrichment(db, entities.toArray(new String[0]), empty, significance, true);
 				
 				HashSet<String> unionSignificant = new HashSet<String>(enrichResultDown.keySet());
 				unionSignificant.removeAll(enrichResultUp.keySet());
@@ -1004,7 +1004,7 @@ public class EnrichmentTemp extends HttpServlet {
 				entities.retainAll(Arrays.asList(((String[]) enrich.datastore.datasets.get(db).getData().get("entity_id"))));
 				
 				if(unionSignificant.size() > 0) {
-					HashMap<String, Result> enrichResultUp2 = enrich.calculateRankEnrichment(db, entities.toArray(new String[0]), unionSignificant, significance);
+					HashMap<String, Result> enrichResultUp2 = enrich.calculateRankEnrichment(db, entities.toArray(new String[0]), unionSignificant, significance, false);
 					enrichResultUp.putAll(enrichResultUp2);
 				}
 				
@@ -1014,7 +1014,7 @@ public class EnrichmentTemp extends HttpServlet {
 				if(unionSignificant.size() > 0) {
 					entities = new HashSet<String>(entity_split_down);
 					entities.retainAll(Arrays.asList(((String[]) enrich.datastore.datasets.get(db).getData().get("entity_id"))));
-					HashMap<String, Result> enrichResultDown2 = enrich.calculateRankEnrichment(db, entities.toArray(new String[0]), unionSignificant, significance);
+					HashMap<String, Result> enrichResultDown2 = enrich.calculateRankEnrichment(db, entities.toArray(new String[0]), unionSignificant, significance, false);
 					enrichResultDown.putAll(enrichResultDown2);
 				}
 				

--- a/src/main/java/serv/EnrichmentTemp.java
+++ b/src/main/java/serv/EnrichmentTemp.java
@@ -433,6 +433,10 @@ public class EnrichmentTemp extends HttpServlet {
 			});
 			JSONObject json = new JSONObject();
 
+			json.put("maxRank", counter);
+			json.put("up", _up_counter);
+			json.put("down", _up_counter);
+			
 			if(_signatures.size() > 0){
 				JSONArray json_signatures = new JSONArray();
 				for(String ui : _signatures){
@@ -681,6 +685,8 @@ public class EnrichmentTemp extends HttpServlet {
 			}
 			json.put("signatures", json_signatures);
 			json.put("maxRank", counter);
+			json.put("mimickers", _mimickers_counter);
+			json.put("reversers", _reversers_counter);
 			json.put("queryTimeSec", (System.currentTimeMillis()*1.0 - _time)/1000);
 			
 			JSONArray json_results = new JSONArray();

--- a/src/main/java/serv/EnrichmentTemp.java
+++ b/src/main/java/serv/EnrichmentTemp.java
@@ -431,7 +431,6 @@ public class EnrichmentTemp extends HttpServlet {
 					
 					JSONObject json_result = new JSONObject();
 					json_result.put("uuid", genesetName);
-					json_result.put("p-value", genesetName);
 					json_result.put("p-value", safeJsonDouble(pval));
 					json_result.put("p-value-bonferroni", safeJsonDouble(pval_bonferroni));
 					json_result.put("fdr", safeJsonDouble(pval_fdr));
@@ -497,7 +496,7 @@ public class EnrichmentTemp extends HttpServlet {
 		}
 	}
 
-	private JSONObject processSignatureJSON(String signature, int rank, double pvalUp, double pvalUpBonferroni, double pvalUpfdr, double pvalDown, double pvalDownBonferroni, double pvalDownfdr, double zUp, double zDown, double zsum, double pvalFisher, double pvalSum, int direction_up, int direction_down) {
+	private JSONObject processRankTwoSidedJSON(String signature, int rank, double pvalUp, double pvalUpBonferroni, double pvalUpfdr, double pvalDown, double pvalDownBonferroni, double pvalDownfdr, double zUp, double zDown, double zsum, double pvalFisher, double pvalSum, int direction_up, int direction_down) {
 		String genesetName = signature;
 		String type = "mimicker";
 		if (zsum < 0) {
@@ -560,6 +559,8 @@ public class EnrichmentTemp extends HttpServlet {
 			double[] zsums = new double[keys.length];
 			int _mimickers_counter = 0;
 			int _reversers_counter = 0;
+			int _mimickers_sig_counter = 0;
+			int _reversers_sig_counter = 0;
 			int _sig_counter = 0;
 			for (String me : sortZscoreSum) { 
 				pvalsUp[counter] = Math.max(enrichResultUp.get(me).pval, Double.MIN_VALUE);
@@ -573,6 +574,11 @@ public class EnrichmentTemp extends HttpServlet {
 				}
 				if ((_signatures.size() > 0 && _signatures.contains(me)) || _signatures.size() == 0) {
 					_sig_counter++;
+					if (zsum > 0) {
+						_mimickers_sig_counter++;
+					} else if (zsum < 0) {
+						_reversers_sig_counter++;
+					}
 				}
 				
 			    counter++;
@@ -612,7 +618,8 @@ public class EnrichmentTemp extends HttpServlet {
 				if (_signatures.size() > 0 && !_signatures.contains(signature)) {
 					included = false;
 				}
-				if (included && _offset_count < Math.min(_offset, _mimickers_counter -1)) {
+				if (included && _offset_count < Math.min(_offset, _mimickers_sig_counter -1)) {
+					System.out.format("offset_count: %d\n", _offset_count);
 					_offset_count++;
 					included = false;
 				}
@@ -636,7 +643,7 @@ public class EnrichmentTemp extends HttpServlet {
 					int direction_up = enrichResultUp.get(signature).direction;
 					int direction_down = enrichResultDown.get(signature).direction;
 
-					JSONObject json_result = processSignatureJSON(signature, i, pvalUp, pvalUpBonferroni, pvalUpfdr, pvalDown, pvalDownBonferroni, pvalDownfdr, zUp, zDown, zsum, pvalFisher, pvalSum, direction_up, direction_down);
+					JSONObject json_result = processRankTwoSidedJSON(signature, i, pvalUp, pvalUpBonferroni, pvalUpfdr, pvalDown, pvalDownBonferroni, pvalDownfdr, zUp, zDown, zsum, pvalFisher, pvalSum, direction_up, direction_down);
 
 					json_results.put(json_result);
 				}
@@ -653,7 +660,7 @@ public class EnrichmentTemp extends HttpServlet {
 				if (_signatures.size() > 0 && !_signatures.contains(signature)) {
 					included = false;
 				}
-				if (included && _offset_count < Math.min(_offset, _reversers_counter -1)) {
+				if (included && _offset_count < Math.min(_offset, _reversers_sig_counter-1)) {
 					_offset_count++;
 					included = false;
 				}
@@ -677,7 +684,7 @@ public class EnrichmentTemp extends HttpServlet {
 					int direction_up = enrichResultUp.get(signature).direction;
 					int direction_down = enrichResultDown.get(signature).direction;
 
-					JSONObject json_result = processSignatureJSON(signature, i, pvalUp, pvalUpBonferroni, pvalUpfdr, pvalDown, pvalDownBonferroni, pvalDownfdr, zUp, zDown, zsum, pvalFisher, pvalSum, direction_up, direction_down);
+					JSONObject json_result = processRankTwoSidedJSON(signature, i, pvalUp, pvalUpBonferroni, pvalUpfdr, pvalDown, pvalDownBonferroni, pvalDownfdr, zUp, zDown, zsum, pvalFisher, pvalSum, direction_up, direction_down);
 
 					json_results.put(json_result);
 				}

--- a/src/main/java/serv/EnrichmentTemp.java
+++ b/src/main/java/serv/EnrichmentTemp.java
@@ -702,7 +702,6 @@ public class EnrichmentTemp extends HttpServlet {
 					included = false;
 				}
 				if (included && _offset_count < Math.min(_offset, _mimickers_sig_counter -1)) {
-					System.out.format("offset_count: %d\n", _offset_count);
 					_offset_count++;
 					included = false;
 				}

--- a/src/main/java/serv/EnrichmentTemp.java
+++ b/src/main/java/serv/EnrichmentTemp.java
@@ -375,9 +375,9 @@ public class EnrichmentTemp extends HttpServlet {
 	}
 
 	private JSONObject processRankJSON(String signature, int rank, double pval, double pval_bonferroni, double pval_fdr, double zscore, int direction) {
-		String type = "mimicker";
+		String type = "up";
 		if (zscore < 0) {
-			type = "reverser";
+			type = "down";
 		}
 		
 		JSONObject json_result = new JSONObject();
@@ -402,25 +402,25 @@ public class EnrichmentTemp extends HttpServlet {
 			
 			Result[] resultArray = new Result[enrichResult.size()];
 			int counter = 0;
-			int _mimickers_counter = 0;
-			int _reversers_counter = 0;
-			int _mimickers_sig_counter = 0;
-			int _reversers_sig_counter = 0;
+			int _up_counter = 0;
+			int _down_counter = 0;
+			int _up_sig_counter = 0;
+			int _down_sig_counter = 0;
 			int _sig_counter = 0;
 			for(String key : enrichResult.keySet()){
 				resultArray[counter] = enrichResult.get(key);
 				counter++;
 				if (enrichResult.get(key).zscore > 0) {
-					_mimickers_counter++;
+					_up_counter++;
 				} else if (enrichResult.get(key).zscore < 0) {
-					_reversers_counter++;
+					_down_counter++;
 				}
 				if ((_signatures.size() > 0 && _signatures.contains(key)) || _signatures.size() == 0) {
 					_sig_counter++;
 					if (enrichResult.get(key).zscore > 0) {
-						_mimickers_sig_counter++;
+						_up_sig_counter++;
 					} else if (enrichResult.get(key).zscore < 0) {
-						_reversers_sig_counter++;
+						_down_sig_counter++;
 					}
 				}
 			}
@@ -466,14 +466,14 @@ public class EnrichmentTemp extends HttpServlet {
 
 			int _offset_count = 0;
 			int _limit_count = 0;
-			for(int i=0; i<_mimickers_counter; i++){
+			for(int i=0; i<_up_counter; i++){
 				Result res = resultArray[i];
 				String signature = res.name;
 				boolean included = true;
 				if (_signatures.size() > 0 && !_signatures.contains(signature)) {
 					included = false;
 				}
-				if (included && _offset_count < Math.min(_offset, _mimickers_sig_counter -1)) {
+				if (included && _offset_count < Math.min(_offset, _up_sig_counter -1)) {
 					_offset_count++;
 					included = false;
 				}
@@ -496,14 +496,14 @@ public class EnrichmentTemp extends HttpServlet {
 			
 			_offset_count = 0;
 			_limit_count = 0;
-			for(int i=counter-1; i>counter-_reversers_counter-1; i--){
+			for(int i=counter-1; i>counter-_down_counter-1; i--){
 				Result res = resultArray[i];
 				String signature = res.name;
 				boolean included = true;
 				if (_signatures.size() > 0 && !_signatures.contains(signature)) {
 					included = false;
 				}
-				if (included && _offset_count < Math.min(_offset, _reversers_sig_counter-1)) {
+				if (included && _offset_count < Math.min(_offset, _down_sig_counter-1)) {
 					_offset_count++;
 					included = false;
 				}
@@ -581,9 +581,9 @@ public class EnrichmentTemp extends HttpServlet {
 
 	private JSONObject processRankTwoSidedJSON(String signature, int rank, double pvalUp, double pvalUpBonferroni, double pvalUpfdr, double pvalDown, double pvalDownBonferroni, double pvalDownfdr, double zUp, double zDown, double zsum, double pvalFisher, double pvalSum, int direction_up, int direction_down) {
 		String genesetName = signature;
-		String type = "mimicker";
+		String type = "mimickers";
 		if (zsum < 0) {
-			type = "reverser";
+			type = "reversers";
 		}
 
 		JSONObject json_result = new JSONObject();

--- a/src/main/java/serv/EnrichmentTemp.java
+++ b/src/main/java/serv/EnrichmentTemp.java
@@ -563,7 +563,7 @@ public class EnrichmentTemp extends HttpServlet {
 			JSONArray json_results = new JSONArray();
 			_response.addHeader("X-Duration", ""+(System.currentTimeMillis()*1.0 - _time)/1000);
 			
-			int sigNum = sortZscoreSum.length
+			int sigNum = sortZscoreSum.length;
 			
 			int _start = Math.min(Math.max(0, _offset), Math.max(0, sigNum-1));
 			int _end = Math.min(_start+Math.max(1, _limit*2), sigNum);
@@ -572,7 +572,7 @@ public class EnrichmentTemp extends HttpServlet {
 			int _mimickers_end = Math.min(_mimickers_start+Math.max(1, _limit), _mimickers_counter);
 
 
-			int _reversers_end =  Math.max(sigNum - Math.max(_offset, 0), sigNum-_reversers_counter)
+			int _reversers_end =  Math.max(sigNum - Math.max(_offset, 0), sigNum-_reversers_counter);
 			int _reversers_start = Math.max(_reversers_end-Math.max(1, _limit), sigNum-_reversers_counter-1);
 			
 			
@@ -632,6 +632,7 @@ public class EnrichmentTemp extends HttpServlet {
 					json_result.put("direction-up", direction_up);
 					json_result.put("direction-down", direction_down);
 					json_result.put("type", type);
+					json_result.put("rank", i);
 
 					json_results.put(json_result);
 				}

--- a/src/main/java/serv/EnrichmentTemp.java
+++ b/src/main/java/serv/EnrichmentTemp.java
@@ -854,12 +854,12 @@ public class EnrichmentTemp extends HttpServlet {
 				HashSet<String > entities = new HashSet<String>(entity_split_up);
 				entities.retainAll(Arrays.asList(((String[]) enrich.datastore.datasets.get(db).getData().get("entity_id"))));
 				signatures.retainAll(Arrays.asList(((String[]) enrich.datastore.datasets.get(db).getData().get("signature_id"))));
-				
-				HashMap<String, Result> enrichResultUp = enrich.calculateRankEnrichment(db, entities.toArray(new String[0]), signatures, significance);
+				HashSet<String> empty = new HashSet<String>();
+				HashMap<String, Result> enrichResultUp = enrich.calculateRankEnrichment(db, entities.toArray(new String[0]), empty, significance);
 				
 				entities = new HashSet<String>(entity_split_down);
 				entities.retainAll(Arrays.asList(((String[]) enrich.datastore.datasets.get(db).getData().get("entity_id"))));
-				HashMap<String, Result> enrichResultDown = enrich.calculateRankEnrichment(db, entities.toArray(new String[0]), signatures, significance);
+				HashMap<String, Result> enrichResultDown = enrich.calculateRankEnrichment(db, entities.toArray(new String[0]), empty, significance);
 				
 				HashSet<String> unionSignificant = new HashSet<String>(enrichResultDown.keySet());
 				unionSignificant.removeAll(enrichResultUp.keySet());

--- a/src/main/java/serv/EnrichmentTemp.java
+++ b/src/main/java/serv/EnrichmentTemp.java
@@ -680,7 +680,7 @@ public class EnrichmentTemp extends HttpServlet {
 				json_signatures.put(ui);
 			}
 			json.put("signatures", json_signatures);
-			
+			json.put("maxRank", counter);
 			json.put("queryTimeSec", (System.currentTimeMillis()*1.0 - _time)/1000);
 			
 			JSONArray json_results = new JSONArray();


### PR DESCRIPTION
I applied the following changes:
1. Previously we sort the results in /enrich/rank and /enrich/ranktwosided by the absolute value of the z-score and z-sum respectively and got the top n results, defined by the limit parameter, this causes a varying number of mimickers and reversers in the results (because you can't just easily tell the API to get the top 50 mimickers and reversers this way). I changed this to sort the plain score (no absolute values). top positive results are labeled as mimickers and bottom negative reversers. I return the top n results on either end, defined by the limit

2. The second modification was to address this issue: https://github.com/MaayanLab/sigcom-lincs/issues/42. So we want a ROC or even a bridge plot to see how signatures for a specific drug are ranked against the other signatures. Technically, the data API don't know the metadata of the UUIDs, but because there is a signatures parameter in the post request, we can use this to send the relevant drug signatures to the data API, and it can perform signature similarity analysis on these signatures but because the data API does the analysis on these signatures only, it's hard to determine the "ranks of the drug across all signatures". So what I did is I added a rank field on the output. I also removed the signature filtering at the start of the analysis, instead, I only filter for signatures at the end before the data is sent back to the client.